### PR TITLE
Changed MongoDB installation instructions

### DIFF
--- a/content/en/pages/starting.jade
+++ b/content/en/pages/starting.jade
@@ -101,7 +101,7 @@ block content
 
 					h3 What do you mean it couldn't find my Database?
 					p By default, KeystoneJS will look for a MongoDB server running on localhost on the default port, and connect to it. If you're getting errors related to the MongoDB connection, make sure your MongoDB server is running.
-					p If you haven't installed MongoDB yet, follow the instructions below.
+					p If you haven't installed MongoDB yet, follow <a href="https://www.mongodb.org/downloads" target="_blank">the official instructions.</a>
 					p To connect to a server other than localhost, add a MONGO_URI setting to the .env file in your Keystone project directory:
 					pre MONGO_URI=mongodb://your-server/database-name
 					


### PR DESCRIPTION
Previously it said to "follow the instructions below", but there were no instructions. This is at least a less confusing hold-over if instructions are still going to be added (although referring to official docs is probably better).
