### PR TITLE
Fixes missing 'locals' with utils variable

### DIFF
--- a/content/en/pages/docs/getting-started.jade
+++ b/content/en/pages/docs/getting-started.jade
@@ -112,6 +112,10 @@ block content
 				| 
 				| require('./models');
 				| 
+				| keystone.set('locals', {
+				|   utils: keystone.utils
+				| });
+				| 
 				| keystone.set('routes', require('./routes'));
 				| 
 				| keystone.start();


### PR DESCRIPTION
utils.isObject is used on templates/mixins/flash-messages.jade

I've found it by following the tutorial, when you run the app and get some message you get "cannot call isObject on undefined"
