### PR TITLE
Document Sass option indentedSyntax

### DIFF
--- a/content/en/pages/docs/configuration.jade
+++ b/content/en/pages/docs/configuration.jade
@@ -159,13 +159,14 @@ block content
 				tr
 					td <code>sass</code> <code class="data-type">String</code> or <code class="data-type">Array</code>
 					td
-						p If you want Keystone to automatically compile <strong>.sass</strong> files into <strong>.css</strong> files, set this value to the same path as the <code>static</code> option.
-						p When this option is set, any requests to a <strong>.css</strong> or <strong>.min.css</strong> file will first check for a <strong>.sass</strong> file with the same name, and if one is found, the css file will be generated.
+						p If you want Keystone to automatically compile <strong>.scss</strong> files into <strong>.css</strong> files, set this value to the same path as the <code>static</code> option.
+						p When this option is set, any requests to a <strong>.css</strong> or <strong>.min.css</strong> file will first check for a <strong>.scss</strong> file with the same name, and if one is found, the css file will be generated.
 						p.note Note that enabling this option requires you to have specified the <a href="https://github.com/sass/node-sass" target="_blank"><code>node-sass</code></a> package as a dependency in your project's <code>package.json</code> file; it is not automatically included with Keystone.
 				tr
 					td <code>sass options</code> <code class="data-type">Object</code>
 					td
 						p Optional config options that will be passed to the <code>sass</code> middleware; see <a href="https://github.com/sass/node-sass#options" target="_blank">github.com/sass/node-sass</a> for more information.
+						p.note To enable complation of <strong>.sass</strong> files pass <code>{ indentedSyntax: true }</code>
 				tr
 					td <code>favicon</code> <code class="data-type">String</code>
 					td


### PR DESCRIPTION
Fixes https://github.com/keystonejs/keystone/issues/1554
Shows user how to get keystone to use .sass files and use the more terse
syntax
