### PR TITLE
Fixing documentation for searchFields to say comma-delimited instead …

### DIFF
--- a/content/en/pages/docs/database.jade
+++ b/content/en/pages/docs/database.jade
@@ -167,7 +167,7 @@ block content
 
 				tr
 					td <code>searchFields</code> <code class="data-type">String</code>
-					td A space-delimited list of paths to use for searching in Admin UI
+					td A comma-delimited list of paths to use for searching in Admin UI
 
 				tr
 					td <code>singular</code> <code class="data-type">String</code>


### PR DESCRIPTION
Fixing [keystonejs/keystone#280](https://github.com/keystonejs/keystone/issues/280) to update documentation for SearchFields to say "comma-delimited" instead of "space-delimited"
