### PR TITLE
Fixing the wrong command instruction to start keystone

### DIFF
--- a/content/en/pages/docs/getting-started.jade
+++ b/content/en/pages/docs/getting-started.jade
@@ -645,7 +645,7 @@ block content
 			h3 Starting Keystone
 			
 			p Now you're ready to run your application, so execute the following in your project's main folder:
-			p: code node web
+			p: code node keystone
 			
 			p Keystone will automatically apply the update, and then start a web server on the default port, 3000.
 			

--- a/content/zh/pages/docs/getting-started.jade
+++ b/content/zh/pages/docs/getting-started.jade
@@ -584,7 +584,7 @@ block content
 			h3 启动Keystone
 			
 			p 现在已经准备好了，在项目主文件夹下执行这个命令运行你的程序吧：
-			p: code node web
+			p: code node keystone
 			
 			p Keystone会自动应用这些更新，然后在默认端口3000上启动web服务器。
 			


### PR DESCRIPTION
This PR fixes the wrong command instruction to run keystone both in English and Chinese.
#50
