### PR TITLE
sortable unshift option

### DIFF
--- a/content/en/pages/docs/database.jade
+++ b/content/en/pages/docs/database.jade
@@ -181,8 +181,11 @@ block content
 					td A <code>List:relationship</code> pair to control when drag and drop sorting is available in the Admin UI
 
 				tr
-					td <code>sortable</code> <code class="data-type">Boolean</code>
-					td Adds a hidden field <code>sortOrder</code> to the schema, and enables drag and drop sorting in the Admin UI
+					td <code>sortable</code> <code class="data-type">Boolean or String</code>
+					td 
+						p Adds a hidden field <code>sortOrder</code> to the schema, and enables drag and drop sorting in the Admin UI.
+						p When set to <code class="data-type">true</code> new documents are added as the last item.
+						p When set to <code class="data-type">unshift</code> new documents are added as the first item.
 
 				tr
 					td <code>track</code> <code class="data-type">Boolean or Object</code>


### PR DESCRIPTION
![screenshot_2016-01-11_21-30-52](https://cloud.githubusercontent.com/assets/6615106/12253062/e268f484-b8aa-11e5-84a7-7a5eee4f0cdb.png)

By the way, our current setup is not using a hidden field.  When it was hidden the Admin UI was not receiving the field to be able to sort with.

Switching back to the hidden field is a simple edit if you can tell me what to change to give the UI access to sortOrder.
