### PR TITLE
Modified database pagination example to use the proper filter method

### DIFF
--- a/content/en/pages/docs/database.jade
+++ b/content/en/pages/docs/database.jade
@@ -351,9 +351,11 @@ block content
 				|  Post.paginate({
 				|		page: req.query.page || 1,
 				|		perPage: 10,
-				|		maxPages: 10
+				|		maxPages: 10,
+				|		filter: {
+				|			'state': 'published'
+				|		}
 				|	})
-				|	.where('state', 'published')
 				|	.sort('-publishedDate')
 				|	.populate('author categories')
 				|	.exec(function(err, results) {

--- a/content/zh/pages/docs/database.jade
+++ b/content/zh/pages/docs/database.jade
@@ -285,9 +285,11 @@ block content
 				|  Post.paginate({
 				|		page: req.query.page || 1,
 				|		perPage: 10,
-				|		maxPages: 10
+				|		maxPages: 10,
+				|		filter: {
+				|			'state': 'published'
+				|		}
 				|	})
-				|	.where('state', 'published')
 				|	.sort('-publishedDate')
 				|	.populate('author categories')
 				|	.exec(function(err, results) {


### PR DESCRIPTION
The previous `where` method caused the returned totals and page counts to all be off - any drafts would throw off the correct numbers, for example. This is more accurate to the expected functionality.
