### PR TITLE
Fix a typo

### DIFF
--- a/content/en/pages/docs/database.jade
+++ b/content/en/pages/docs/database.jade
@@ -567,7 +567,7 @@ block content
 				li The value of any other field (or fields) changes
 				li The value of any other field (or fields) changes to a specific value
 			
-			p To use the watching functionaliy, set the following two options:
+			p To use the watching functionality, set the following two options:
 				
 			table.table
 				col(width=210)


### PR DESCRIPTION
`functionaliy` → `functionality`
