### PR TITLE
Add size field options in database documentation

### DIFF
--- a/content/en/pages/docs/database.jade
+++ b/content/en/pages/docs/database.jade
@@ -514,12 +514,15 @@ block content
 				tr
 					td <code>hidden</code> <code class="data-type">Boolean</code>
 					td The field will always be hidden in the Admin UI if this is set to <code class="default-value">true</code>
-			
+				tr
+					td <code>size</code> <code class="data-type">String</code>
+					td Sets the size of the field in the admin UI. Valid options are small, medium, large, and full
+
 			a(name="fields-conditional")
 			h3 Conditional Fields
-			
+
 			p To improve the usability of the Admin UI, it is possible to hide fields when no value is set, or depending on the value of other fields.
-			
+
 			table.table
 				col(width=210)
 				col


### PR DESCRIPTION
Update English documentation per the following issue: https://github.com/keystonejs/keystone/issues/1286
