### PR TITLE
Remove BBCode Option

### DIFF
--- a/content/en/pages/docs/configuration.jade
+++ b/content/en/pages/docs/configuration.jade
@@ -539,7 +539,7 @@ block content
 								|  + ' charmap ltr rtl pagebreak paste, forecolor backcolor,'
 								|  +' emoticons media, preview print ',
 								| 'wysiwyg additional plugins': 'example, table, advlist, anchor,'
-								|  + ' autolink, autosave, bbcode, charmap, contextmenu, '
+								|  + ' autolink, autosave, charmap, contextmenu, '
 								|  + ' directionality, emoticons, fullpage, hr, media, pagebreak,'
 								|  + ' paste, preview, print, searchreplace, textcolor,'
 								|  + ' visualblocks, visualchars, wordcount',


### PR DESCRIPTION
BBCode is useless for Keystone and people are prone to copy-and-pasting.  :)
