### PR TITLE
Default Date Time Format Made Consistent

### DIFF
--- a/content/en/pages/docs/database.jade
+++ b/content/en/pages/docs/database.jade
@@ -789,7 +789,7 @@ block content
 			.options
 				
 				h5 Options:
-				p <code>format</code> <code class="data-type">string</code> - the default format pattern to use, defaults to <code class="default-value">Do MMM YYYY hh:mm:ss a</code>
+				p <code>format</code> <code class="data-type">string</code> - the default format pattern to use, defaults to <code class="default-value">YYYY-MM-DD h:m:s a</code>
 				p See the <a href="http://momentjs.com/docs/#/displaying/format/" target="_blank">momentjs format docs</a> for information on the supported formats and options.
 				
 				h5 Underscore methods:


### PR DESCRIPTION
It is a fix for http://keystonejs.com/docs/database/#fieldtypes-datetime in which the default format pattern Do-MMM-YYYY hh:mm:ss a has been changed to YYYY-MM-DD h : m : s a.
