### PR TITLE
correct library linked

### DIFF
--- a/content/en/pages/docs/configuration.jade
+++ b/content/en/pages/docs/configuration.jade
@@ -220,7 +220,7 @@ block content
 				tr
 					td <code>sass options</code> <code class="data-type">Object</code>
 					td
-						p Optional config options that will be passed to the <code>sass</code> middleware; see <a href="https://github.com/sass/node-sass#options" target="_blank">github.com/sass/node-sass</a> for more information.
+						p Optional config options that will be passed to the <code>sass</code> middleware; see <a href="https://github.com/sass/node-sass-middleware#options" target="_blank">github.com/sass/node-sass-middleware</a> for more information.
 						p.note To enable complation of <strong>.sass</strong> files pass <code>{ indentedSyntax: true }</code>
 				tr
 					td <code>favicon</code> <code class="data-type">String</code>


### PR DESCRIPTION
Since optional config options are passed to sass middleware, so the documentation will link it to that library instead of node-sass. Change made.
